### PR TITLE
Support for systemd-networkd under Gentoo

### DIFF
--- a/novaagent/libs/gentoo_systemd_networkd.py
+++ b/novaagent/libs/gentoo_systemd_networkd.py
@@ -1,0 +1,73 @@
+from __future__ import print_function, absolute_import
+import os
+
+from novaagent import utils
+from subprocess import Popen, PIPE
+
+from novaagent.libs import DefaultOS
+
+
+class ServerOS(DefaultOS):
+    def _setup_interface(self, ifname, iface):
+        addrs = []
+        addrs.extend(['{0}/{1}'.format(x['ip'], utils.netmask_to_prefix(x['netmask'])) for x in iface['ips']])
+        if 'ip6s' in iface and iface['ip6s']:
+            addrs.extend(['{ip}/{netmask}'.format(**x) for x in iface['ip6s']])
+        routes = []
+        gateways = []
+        if 'gateway' in iface and iface['gateway']:
+            gateways.append(iface['gateway'])
+        if 'gateway_v6' in iface and iface['gateway_v6']:
+            gateways.append(iface['gateway_v6'])
+        if 'routes' in iface and iface['routes']:
+            for route in iface['routes']:
+                route['length'] = utils.netmask_to_prefix(route['netmask'])
+                routes.append(route)
+
+        utils.backup_file('/etc/systemd/network/{0}.network'.format(ifname))
+        with open('/etc/systemd/network/{0}.network'.format(ifname), 'w') as iffile:
+            print('# Label {0}'.format(iface['label']), file=iffile)
+            print('[Match]\nName={0}\n'.format(ifname), file=iffile)
+            print('[Network]', file=iffile)
+            for x in addrs:
+                print('Address={0}'.format(x), file=iffile)
+            for x in gateways:
+                print('Gateway={0}'.format(x), file=iffile)
+            if 'dns' in iface and iface['dns']:
+                print('DNS={0}'.format(' '.join(iface['dns'])), file=iffile)
+            for x in routes:
+                print('\n[Route]\nGateway={gateway}\nDestination={route}/{length}'.format(**route), file=iffile)
+
+    def resetnetwork(self, name, value):
+        ifaces = {}
+        xen_macs = utils.list_xenstore_macaddrs()
+        for iface in utils.list_hw_interfaces():
+            mac = utils.get_hw_addr(iface)
+            if not mac or mac not in xen_macs:
+                continue
+            ifaces[iface] = utils.get_interface(mac)
+
+        # set hostname
+        utils.backup_file('/etc/hostname')
+        hostname = utils.get_hostname()
+        with open('/etc/hostname', 'w') as hostnamefile:
+            print(hostname, file=hostnamefile)
+        p = Popen(['hostname', hostname], stdout=PIPE, stderr=PIPE, stdin=PIPE)
+        out, err = p.communicate()
+        if p.returncode != 0:
+            return (str(p.returncode), 'Error setting hostname: hostname')
+
+        # setup interface files
+        for ifname, iface in ifaces.items():
+            self._setup_interface(ifname, iface)
+
+        p = Popen(['/usr/bin/systemctl', 'restart', 'systemd-networkd'], stdout=PIPE, stderr=PIPE, stdin=PIPE)
+        out, err = p.communicate()
+        if p.returncode != 0:
+            return (str(p.returncode), 'Error restarting network')
+
+        return ('0', '')
+
+
+if __name__ == '__main__':
+    main()

--- a/novaagent/libs/gentoo_systemd_networkd.py
+++ b/novaagent/libs/gentoo_systemd_networkd.py
@@ -28,6 +28,7 @@ class ServerOS(DefaultOS):
         with open('/etc/systemd/network/{0}.network'.format(ifname), 'w') as iffile:
             print('# Label {0}'.format(iface['label']), file=iffile)
             print('[Match]\nName={0}\n'.format(ifname), file=iffile)
+            print('[Link]\nMACAddress={0}\n'.format(iface['mac']), file=iffile)
             print('[Network]', file=iffile)
             for x in addrs:
                 print('Address={0}'.format(x), file=iffile)

--- a/novaagent/novaagent.py
+++ b/novaagent/novaagent.py
@@ -5,6 +5,7 @@ import json
 import os
 import sys
 import argparse
+from subprocess import Popen, PIPE
 
 from novaagent import utils
 from novaagent.libs import (
@@ -13,6 +14,7 @@ from novaagent.libs import (
     debian,
     freebsd,
     gentoo,
+    gentoo_systemd_networkd,
     redhat,
     suse,
 )
@@ -66,6 +68,10 @@ def main():
         servertype = debian
     elif os.path.exists('/etc/gentoo-release'):
         servertype = gentoo
+        p = Popen(["/bin/pidof", "systemd-networkd"], stdout=PIPE, stderr=PIPE, stdin=PIPE)
+        out, err = p.communicate()
+        if p.returncode == 0:
+            servertype = gentoo_systemd_networkd
     elif os.path.exists('/etc/susehelp.d/'):
         servertype = suse
     elif os.path.exists('/etc/rc.conf'):


### PR DESCRIPTION
Based off the gentoo module, add the ability to reset network files
when running systemd-networkd.

The main change from the Gentoo networking scripts is that gateways can
be set in the main [Network] section or separate [Route] sections, but
additional routes have to be set in [Route].

/etc/conf.d/hostname is not required for systemd
