### PR TITLE
license clean up

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,8 +1,11 @@
-Copyright 2016 by Daniel Wallace
+Copyright 2017 Rackspace, Inc.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-   http://www.apache.org/licenses/LICENSE-2.0
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pkgs/nova-agent.spec
+++ b/pkgs/nova-agent.spec
@@ -116,7 +116,7 @@ fi
 
 
 %files
-%license LICENSE.txt
+%license LICENSE
 %if %{with python3}
 %{python3_sitelib}/novaagent*
 %else


### PR DESCRIPTION
Set the copyright to Rackspace and rename the file for simplicity.