### PR TITLE
Use systemd bindings to send a notification.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,47 @@
 
 language: python
-python:
-  - "2.6"
-  - "2.7"
-  - "3.4"
-  - "3.5"
-  - "3.6"
-install:
-  - pip install -e .[tests]
 before_script:
   - flake8 .
 script:
   - nosetests -v --cover-erase --with-coverage --cover-package=novaagent
+
+python:
+  - "2.7"
+  - "3.5"
+  - "3.6"
+
+env:
+  - RELEASE=16.04 TYPE=pypi
+  - RELEASE=16.04 TYPE=nosystemd
+
+dist: xenial
+
+install:
+  - pip install -e .[tests]
+  - sudo apt update -qq
+  - if [ $TYPE = pypi ]; then sudo apt install libsystemd-dev; fi
+  - if [ $TYPE = pypi ]; then pip install -e .[systemd]; fi
+  - if [ $TYPE = dist2 ]; then sudo apt install python-systemd; fi
+  - if [ $TYPE = dist3 ]; then sudo apt install python3-systemd; fi
+
+matrix:
+  include:
+    # 2.6 & 3.4 can only be tested on trusty
+    - python: "2.6"
+      env:  RELEASE=14.04 TYPE=nosystemd
+      dist: trusty
+    - python: "3.4"
+      env:  RELEASE=14.04 TYPE=nosystemd
+      dist: trusty
+    # Test with dist python-systemd
+    ## trusty with v2.7
+    - python: "2.7"
+      env:  RELEASE=14.04 TYPE=dist2
+      dist: trusty
+    ## xenial with v2.7 & v3.5
+    - python: "2.7"
+      env: RELEASE=16.04 TYPE=dist2
+      dist: xenial
+    - python: "3.5"
+      env: RELEASE=16.04 TYPE=dist3
+      dist: xenial

--- a/etc/nova-agent.service
+++ b/etc/nova-agent.service
@@ -1,12 +1,11 @@
 [Unit]
 Description=Nova Agent for xenstore
-Wants=local-fs.target
 Before=network-pre.target
 After=cloud-init-local.service
 
 [Service]
-Type=forking
-ExecStart=/usr/bin/nova-agent -o /var/log/nova-agent.log -l info
+Type=notify
+ExecStart=/usr/bin/nova-agent --no-fork -o /var/log/nova-agent.log -l info
 
 [Install]
 WantedBy=multi-user.target

--- a/etc/nova-agent.upstart
+++ b/etc/nova-agent.upstart
@@ -6,7 +6,7 @@ stop on runlevel [!2345]
 
 respawn
 respawn limit 10 5
-expect fork
+expect stop
 umask 022
 
-exec /usr/bin/nova-agent -o /var/log/nova-agent.log -l info
+exec /usr/bin/nova-agent --no-fork -o /var/log/nova-agent.log -l info

--- a/novaagent/novaagent.py
+++ b/novaagent/novaagent.py
@@ -56,6 +56,40 @@ def action(server_os, client=None):
         )
 
 
+_ready = False
+
+
+def notify_ready():
+    """
+    Use systemd notify protocol, or upstart sigstop, to notify
+    rediness of the nova-agent.
+    """
+
+    global _ready
+
+    if _ready:
+        return
+
+    # PyPI edition of python-systemd
+    try:
+        from systemd.daemon import notify, Notification
+        notify(Notification.READY)
+    # Older v234 python-systemd
+    except ImportError:
+        try:
+            from systemd.daemon import notify
+            notify('READY=1')
+        except ImportError:
+            pass
+
+    # Upstart notification type
+    if os.environ.get('UPSTART_JOB'):
+        import signal
+        os.kill(os.getpid(), signal.SIGSTOP)
+
+    _ready = True
+
+
 def nova_agent_listen(server_type, server_os):
     log.info('Starting actions for {0}'.format(server_type.__name__))
     log.info('Checking for existence of /dev/xen/xenbus')
@@ -64,11 +98,13 @@ def nova_agent_listen(server_type, server_os):
             check_provider(utils.get_provider(client=xenbus_client))
             while True:
                 action(server_os, client=xenbus_client)
+                notify_ready()
                 time.sleep(1)
     else:
         check_provider(utils.get_provider())
         while True:
             action(server_os)
+            notify_ready()
             time.sleep(1)
 
 
@@ -108,7 +144,7 @@ def create_parser():
         '--no-fork',
         dest='no_fork',
         default=False,
-        type=bool,
+        action='store_true',
         help='Perform os.fork when starting agent'
     )
     return parser

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,8 @@ setuptools.setup(
     author_email='david.kludt@rackspace.com',
     install_requires=requirements,
     extras_require={
-        'tests': test_requirements
+        'tests': test_requirements,
+        'systemd': ['systemd'],
     },
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
- fix no-fork flag to be argument-less flag
- add startup notification support, to indicate when the service is up
- uses 'python-systemd' package bindings (e.g. those that used to ship in src:systemd, later became stand alone source package python-systemd, or using alternative bindings shipped in PyPI with identical name)