### PR TITLE
Use socket module to send a notification.

### DIFF
--- a/etc/nova-agent.service
+++ b/etc/nova-agent.service
@@ -1,12 +1,11 @@
 [Unit]
 Description=Nova Agent for xenstore
-Wants=local-fs.target
 Before=network-pre.target
 After=cloud-init-local.service
 
 [Service]
-Type=forking
-ExecStart=/usr/bin/nova-agent -o /var/log/nova-agent.log -l info
+Type=notify
+ExecStart=/usr/bin/nova-agent --no-fork -o /var/log/nova-agent.log -l info
 
 [Install]
 WantedBy=multi-user.target

--- a/etc/nova-agent.upstart
+++ b/etc/nova-agent.upstart
@@ -6,7 +6,7 @@ stop on runlevel [!2345]
 
 respawn
 respawn limit 10 5
-expect fork
+expect stop
 umask 022
 
-exec /usr/bin/nova-agent -o /var/log/nova-agent.log -l info
+exec /usr/bin/nova-agent --no-fork -o /var/log/nova-agent.log -l info


### PR DESCRIPTION
- fix no-fork flag to be argument-less flag
- add startup notification support, to indicate when the service is up
- uses pure-python 'socket' module without any new runtime dependencies