### PR TITLE
Use DefaultDependencies=no to prevent forming service ordering cycles

### DIFF
--- a/etc/nova-agent.service
+++ b/etc/nova-agent.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Nova Agent for xenstore
+DefaultDependencies=no
 Wants=cloud-init-local.service
 Before=network-online.target
 Before=cloud-init.service


### PR DESCRIPTION
1bdc672003bb10c49886271e42934df01ac2e86e added Before=cloud-init.service
which service sets DefaultDependencies=no thus nova-agent.service
shouls also set it. Nova-agent is run early in boot thus it should have set
DefaultDependencies=no anyway.