### PR TITLE
clear NOTIFY_SOCKET environment variable correctly

### DIFF
--- a/tests/tests_utils.py
+++ b/tests/tests_utils.py
@@ -816,7 +816,7 @@ class TestHelpers(TestCase):
     def test_notify_empty_address(self):
         address = None
         socket = None
-        with mock.patch.dict(os.environ, {'BAD_THINGS': '0'}):
+        with mock.patch.dict(os.environ, clear=True):
             bad_address, bad_socket = utils.notify_socket()
 
         self.assertEqual(


### PR DESCRIPTION
The goal of this test is to ensure utils.notify_socket returns the
correct None values when NOTIFY_SOCKET is not set.  However,
mock.patch.dict by default only adds to the in_dict, it doesn't clear
it.  This test passed up until now just by concidence of NOTIFY_SOCKET
not being set in Travis or in RPM mock (not the same thing as python
mock) builds.  RPM mock now using systemd-nspawn, which sets
NOTIFY_SOCKET, exposing the flaw.