### PR TITLE
Fedora 29 version comparison fix and RHEL/CentOS 8.0 instead of 7.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-  - "3.7"
+  - "3.7-dev"
 install:
   - pip install -e .[tests]
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,11 @@
 
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "3.4"
   - "3.5"
   - "3.6"
-  - "3.7-dev"
+  - "3.7"
 install:
   - pip install -e .[tests]
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 
 language: python
 python:
+  - "2.6"
   - "2.7"
   - "3.4"
   - "3.5"

--- a/novaagent/libs/centos.py
+++ b/novaagent/libs/centos.py
@@ -171,7 +171,7 @@ class ServerOS(DefaultOS):
 
         log.info("Linux Distribution Detected: {0} Version {1}".format(
             dist, ServerOS.version_tuple()))
-        if dist in ['rhel', 'centos'] and server_os_version >= (8,):
+        if dist in ['rhel', 'centos'] and server_os_version >= (8, 0):
             return True
         if dist == 'fedora' and server_os_version >= (29,):
             return True

--- a/novaagent/libs/centos.py
+++ b/novaagent/libs/centos.py
@@ -177,7 +177,7 @@ class ServerOS(DefaultOS):
         dist = distro.id()
         server_os_version = ServerOS.version_tuple()
 
-        log.info("Linux Distribution Detected: {} Version {}".format(
+        log.info("Linux Distribution Detected: {0} Version {1}".format(
             dist, ServerOS.version_tuple()))
         if dist in ['rhel', 'centos'] and server_os_version >= (8, 0):
             return True
@@ -211,7 +211,7 @@ class ServerOS(DefaultOS):
                 result = True
         except Exception as e:
             log.info(
-                'Error checking if NetworkManager is enabled {}'.format(e))
+                'Error checking if NetworkManager is enabled {0}'.format(e))
             log.info('Falling back to service network restart')
 
         return result

--- a/novaagent/libs/centos.py
+++ b/novaagent/libs/centos.py
@@ -1,6 +1,4 @@
-
 from __future__ import absolute_import
-
 
 import logging
 import os
@@ -10,10 +8,8 @@ import distro
 from subprocess import Popen
 from subprocess import PIPE
 
-
 from novaagent import utils
 from novaagent.libs import DefaultOS
-
 
 log = logging.getLogger(__name__)
 
@@ -161,10 +157,6 @@ class ServerOS(DefaultOS):
     def version_tuple():
         """Tuple representation of os version"""
         version = distro.version().split('.')
-        if len(version) < 2:
-            # Tuple comparision doesn't like comparing different sized tuples.
-            version.append(0)
-
         version = map(int, version)
         return tuple(version)
 
@@ -179,9 +171,9 @@ class ServerOS(DefaultOS):
 
         log.info("Linux Distribution Detected: {0} Version {1}".format(
             dist, ServerOS.version_tuple()))
-        if dist in ['rhel', 'centos'] and server_os_version >= (8, 0):
+        if dist in ['rhel', 'centos'] and server_os_version >= (8,):
             return True
-        if dist == 'fedora' and server_os_version >= (29, 0):
+        if dist == 'fedora' and server_os_version >= (29,):
             return True
 
         return False
@@ -207,7 +199,7 @@ class ServerOS(DefaultOS):
             out, err = p.communicate()
             if p.returncode != 0:
                 return False
-            if b'enabled' in out:
+            if 'enabled'.encode() in out:
                 result = True
         except Exception as e:
             log.info(

--- a/tests/tests_libs_centos.py
+++ b/tests/tests_libs_centos.py
@@ -15,11 +15,20 @@ if sys.version_info[:2] >= (2, 7):
 else:
     from unittest2 import TestCase
 
-
 try:
     from unittest import mock
 except ImportError:
     import mock
+
+
+class MockDistro(object):
+    def id(self):
+        print("ID Fedora")
+        return 'fedora'
+
+    def vesion(self):
+        print("Version 29")
+        return ['29']
 
 
 class TestHelpers(TestCase):
@@ -64,7 +73,9 @@ class TestHelpers(TestCase):
         with open('/tmp/network', 'a+') as f:
             f.write('This is a test file')
 
-    def test_initialization(self):
+    @mock.patch('novaagent.libs.centos.ServerOS.is_network_manager')
+    def test_initialization(self, mock_distro):
+        mock_distro.return_value = False
         temp = centos.ServerOS()
         self.assertEqual(
             temp.netconfig_dir,
@@ -92,7 +103,9 @@ class TestHelpers(TestCase):
             'Network file location is not expected value'
         )
 
-    def test_reset_network_hostname_failure(self):
+    @mock.patch('novaagent.libs.centos.ServerOS.is_network_manager')
+    def test_reset_network_hostname_failure(self, mock_distro):
+        mock_distro.return_value = False
         self.setup_temp_route()
         self.setup_temp_interface_config('eth1')
         self.setup_temp_interface_config('lo')
@@ -199,7 +212,9 @@ class TestHelpers(TestCase):
             'Localhost ifcfg file was moved out of the way and should not have'
         )
 
-    def test_reset_network_flush_failure(self):
+    @mock.patch('novaagent.libs.centos.ServerOS.is_network_manager')
+    def test_reset_network_flush_failure(self, mock_distro):
+        mock_distro.return_value = False
         self.setup_temp_route()
         self.setup_temp_interface_config('eth1')
         self.setup_temp_interface_config('lo')
@@ -313,7 +328,9 @@ class TestHelpers(TestCase):
             'Localhost ifcfg file was moved out of the way and should not have'
         )
 
-    def test_reset_network_success(self):
+    @mock.patch('novaagent.libs.centos.ServerOS.is_network_manager')
+    def test_reset_network_success(self, mock_distro):
+        mock_distro.return_value = False
         self.setup_temp_route()
         self.setup_temp_interface_config('eth1')
         self.setup_temp_interface_config('lo')
@@ -401,7 +418,8 @@ class TestHelpers(TestCase):
             'Localhost ifcfg file was moved out of the way and should not have'
         )
 
-    def test_reset_network_error(self):
+    @mock.patch('novaagent.libs.centos.ServerOS.is_network_manager')
+    def test_reset_network_error(self, mock_distro):
         self.setup_temp_route()
         self.setup_temp_interface_config('eth1')
         self.setup_temp_interface_config('lo')
@@ -483,7 +501,9 @@ class TestHelpers(TestCase):
             'Localhost ifcfg file was moved out of the way and should not have'
         )
 
-    def test_reset_network_success_systemctl(self):
+    @mock.patch('novaagent.libs.centos.ServerOS.is_network_manager')
+    def test_reset_network_success_systemctl(self, mock_distro):
+        mock_distro.return_value = False
         self.setup_temp_route()
         self.setup_temp_interface_config('eth1')
         self.setup_temp_interface_config('lo')
@@ -580,7 +600,8 @@ class TestHelpers(TestCase):
             'Localhost ifcfg file was moved out of the way and should not have'
         )
 
-    def test_reset_network_error_systemctl(self):
+    @mock.patch('novaagent.libs.centos.ServerOS.is_network_manager')
+    def test_reset_network_error_systemctl(self, mock_distro):
         self.setup_temp_route()
         self.setup_temp_interface_config('eth1')
         self.setup_temp_interface_config('lo')
@@ -680,7 +701,8 @@ class TestHelpers(TestCase):
             'Localhost ifcfg file was moved out of the way and should not have'
         )
 
-    def test_check_extra_args(self):
+    @mock.patch('novaagent.libs.centos.ServerOS.is_network_manager')
+    def test_check_extra_args(self, mock_distro):
         self.setup_temp_interface_config('eth1')
         temp = centos.ServerOS()
         interface_file = '/tmp/ifcfg-eth1'
@@ -697,7 +719,8 @@ class TestHelpers(TestCase):
             'Did not get proper extra arguments from check'
         )
 
-    def test_check_extra_args_no_file(self):
+    @mock.patch('novaagent.libs.centos.ServerOS.is_network_manager')
+    def test_check_extra_args_no_file(self, mock_distro):
         temp = centos.ServerOS()
         interface_file = '/tmp/ifcfg-eth1'
 
@@ -713,7 +736,9 @@ class TestHelpers(TestCase):
             'Did not get proper extra arguments from check'
         )
 
-    def test_setup_routes(self):
+    @mock.patch('novaagent.libs.centos.ServerOS.is_network_manager')
+    def test_setup_routes(self, mock_distro):
+        mock_distro.return_value = False
         self.setup_temp_route()
         temp = centos.ServerOS()
         temp.netconfig_dir = '/tmp'
@@ -735,7 +760,9 @@ class TestHelpers(TestCase):
                 'Written file did not match expected value'
             )
 
-    def test_setup_interfaces_eth0(self):
+    @mock.patch('novaagent.libs.centos.ServerOS.is_network_manager')
+    def test_setup_interfaces_eth0(self, mock_distro):
+        mock_distro.return_value = False
         self.setup_temp_interface_config('eth0')
         temp = centos.ServerOS()
         temp.netconfig_dir = '/tmp'
@@ -758,7 +785,9 @@ class TestHelpers(TestCase):
                 'Written file did not match expected value'
             )
 
-    def test_setup_interfaces_eth1(self):
+    @mock.patch('novaagent.libs.centos.ServerOS.is_network_manager')
+    def test_setup_interfaces_eth1(self, mock_distro):
+        mock_distro.return_value = False
         self.setup_temp_interface_config('eth1')
         temp = centos.ServerOS()
         temp.netconfig_dir = '/tmp'
@@ -781,7 +810,9 @@ class TestHelpers(TestCase):
                 'Written file did not match expected value'
             )
 
-    def test_setup_hostname_hostname_success(self):
+    @mock.patch('novaagent.libs.centos.ServerOS.is_network_manager')
+    def test_setup_hostname_hostname_success(self, mock_distro):
+        mock_distro.return_value = False
         self.setup_temp_hostname()
         temp = centos.ServerOS()
         temp.hostname_file = '/tmp/hostname'
@@ -810,7 +841,9 @@ class TestHelpers(TestCase):
             'Return code received was not expected value'
         )
 
-    def test_setup_hostname_hostname_failure(self):
+    @mock.patch('novaagent.libs.centos.ServerOS.is_network_manager')
+    def test_setup_hostname_hostname_failure(self, mock_distro):
+        mock_distro.return_value = False
         self.setup_temp_hostname()
         temp = centos.ServerOS()
         temp.hostname_file = '/tmp/hostname'
@@ -839,7 +872,9 @@ class TestHelpers(TestCase):
             'Return code received was not expected value'
         )
 
-    def test_setup_hostname_hostnamectl_success(self):
+    @mock.patch('novaagent.libs.centos.ServerOS.is_network_manager')
+    def test_setup_hostname_hostnamectl_success(self, mock_distro):
+        mock_distro.return_value = False
         self.setup_temp_hostname()
         temp = centos.ServerOS()
         temp.hostname_file = '/tmp/hostname'
@@ -868,7 +903,9 @@ class TestHelpers(TestCase):
             'Return code received was not expected value'
         )
 
-    def test_setup_hostname_hostnamectl_failure(self):
+    @mock.patch('novaagent.libs.centos.ServerOS.is_network_manager')
+    def test_setup_hostname_hostnamectl_failure(self, mock_distro):
+        mock_distro.return_value = False
         self.setup_temp_hostname()
         temp = centos.ServerOS()
         temp.hostname_file = '/tmp/hostname'
@@ -895,4 +932,72 @@ class TestHelpers(TestCase):
             return_code,
             1,
             'Return code received was not expected value'
+        )
+
+    @mock.patch('novaagent.libs.centos.distro.id', return_value='rhel')
+    @mock.patch('novaagent.libs.centos.distro.version', return_value='7.5')
+    def test_os_defaults_network_manager_rhel_pre_8(self, mock_id, mock_ver):
+        temp = centos.ServerOS()
+        results = temp._os_defaults_network_manager()
+        self.assertEqual(
+            results,
+            False,
+            'Should have returned False: {0}'.format(results)
+        )
+
+    @mock.patch('novaagent.libs.centos.distro.id', return_value='rhel')
+    @mock.patch('novaagent.libs.centos.distro.version', return_value='8.0')
+    def test_os_defaults_network_manager_rhel_8(self, mock_id, mock_ver):
+        temp = centos.ServerOS()
+        results = temp._os_defaults_network_manager()
+        self.assertEqual(
+            results,
+            True,
+            'Should have returned True: {0}'.format(results)
+        )
+
+    @mock.patch('novaagent.libs.centos.distro.id', return_value='fedora')
+    @mock.patch('novaagent.libs.centos.distro.version', return_value='28')
+    def test_os_defaults_network_manager_fedora_pre_29(self,
+                                                       mock_id,
+                                                       mock_ver):
+        temp = centos.ServerOS()
+        results = temp._os_defaults_network_manager()
+        self.assertEqual(
+            results,
+            False,
+            'Should have returned False: {0}'.format(results)
+        )
+
+    @mock.patch('novaagent.libs.centos.distro.id', return_value='fedora')
+    @mock.patch('novaagent.libs.centos.distro.version', return_value='29')
+    def test_os_defaults_network_manager_fedora_29(self, mock_id, mock_ver):
+        temp = centos.ServerOS()
+        results = temp._os_defaults_network_manager()
+        self.assertEqual(
+            results,
+            True,
+            'Should have returned True: {0}'.format(results)
+        )
+
+    @mock.patch('novaagent.libs.centos.ServerOS._os_defaults_network_manager')
+    def test_is_network_manager_true(self, mock_default_netman):
+        mock_default_netman.return_value = True
+        temp = centos.ServerOS()
+        results = temp._os_defaults_network_manager()
+        self.assertEqual(
+            results,
+            True,
+            'Should have returned True: {0}'.format(results)
+        )
+
+    @mock.patch('novaagent.libs.centos.ServerOS._os_defaults_network_manager')
+    def test_is_network_manager_false(self, mock_default_netman):
+        mock_default_netman.return_value = False
+        temp = centos.ServerOS()
+        results = temp._os_defaults_network_manager()
+        self.assertEqual(
+            results,
+            False,
+            'Should have returned False: {0}'.format(results)
         )

--- a/tests/tests_libs_redhat.py
+++ b/tests/tests_libs_redhat.py
@@ -25,7 +25,9 @@ class TestHelpers(TestCase):
     def tearDown(self):
         logging.disable(logging.NOTSET)
 
-    def test_redhat_kmsactivate(self):
+    @mock.patch('novaagent.libs.centos.ServerOS.is_network_manager')
+    def test_redhat_kmsactivate(self, mock_distro):
+        mock_distro.return_value = False
         temp = redhat.ServerOS()
         with mock.patch('novaagent.common.kms.kms_activate') as kms:
             kms.return_value = ("0", "")

--- a/tests/tests_novaagent.py
+++ b/tests/tests_novaagent.py
@@ -33,7 +33,9 @@ class TestHelpers(TestCase):
 
         self.time_patcher.stop()
 
-    def test_xen_action_no_action(self):
+    @mock.patch('novaagent.libs.centos.ServerOS.is_network_manager')
+    def test_xen_action_no_action(self, mock_distro):
+        mock_distro.return_value = False
         temp_os = centos.ServerOS()
         test_xen_event = {
             "name": "bad_key",
@@ -66,7 +68,9 @@ class TestHelpers(TestCase):
                                 'An exception was thrown during action'
                             )
 
-    def test_xen_action_action_success(self):
+    @mock.patch('novaagent.libs.centos.ServerOS.is_network_manager')
+    def test_xen_action_action_success(self, mock_distro):
+        mock_distro.return_value = False
         temp_os = centos.ServerOS()
         test_xen_event = {
             "name": "keyinit",
@@ -101,7 +105,9 @@ class TestHelpers(TestCase):
                                     'An exception was thrown during action'
                                 )
 
-    def test_xen_action_action_success_network(self):
+    @mock.patch('novaagent.libs.centos.ServerOS.is_network_manager')
+    def test_xen_action_action_success_network(self, mock_distro):
+        mock_distro.return_value = False
         temp_os = centos.ServerOS()
         test_xen_event = {
             "name": "resetnetwork",
@@ -138,7 +144,9 @@ class TestHelpers(TestCase):
                                     'An exception was thrown during action'
                                 )
 
-    def test_xen_action_action_no_events(self):
+    @mock.patch('novaagent.libs.centos.ServerOS.is_network_manager')
+    def test_xen_action_action_no_events(self, mock_distro):
+        mock_distro.return_value = False
         temp_os = centos.ServerOS()
         with mock.patch('novaagent.utils.list_xen_events') as xen_list:
             xen_list.return_value = []
@@ -157,7 +165,10 @@ class TestHelpers(TestCase):
                     'An exception was thrown during action'
                 )
 
-    def test_main_success(self):
+    @mock.patch('novaagent.libs.centos.ServerOS.is_network_manager')
+    def test_main_success(self, mock_distro):
+        mock_distro.return_value = False
+
         class Test(object):
             def __init__(self):
                 self.logfile = '/tmp/log'
@@ -207,7 +218,10 @@ class TestHelpers(TestCase):
                                                     'An exception was thrown'
                                                 )
 
-    def test_main_success_no_fork(self):
+    @mock.patch('novaagent.libs.centos.ServerOS.is_network_manager')
+    def test_main_success_no_fork(self, mock_distro):
+        mock_distro.return_value = False
+
         class Test(object):
             def __init__(self):
                 self.logfile = '-'
@@ -229,6 +243,7 @@ class TestHelpers(TestCase):
                 'novaagent.novaagent.get_server_type'
             ) as server_type:
                 server_type.return_value = centos
+
                 with mock.patch(
                     'novaagent.novaagent.get_init_system'
                 ) as init_system:
@@ -254,7 +269,10 @@ class TestHelpers(TestCase):
                                             'An unknown exception was thrown'
                                         )
 
-    def test_main_success_with_xenbus(self):
+    @mock.patch('novaagent.libs.centos.ServerOS.is_network_manager')
+    def test_main_success_with_xenbus(self, mock_distro):
+        mock_distro.return_value = False
+
         class Test(object):
             def __init__(self):
                 self.logfile = '-'
@@ -353,7 +371,10 @@ class TestHelpers(TestCase):
                             finally:
                                 return
 
-    def test_main_success_systemd(self):
+    @mock.patch('novaagent.libs.centos.ServerOS.is_network_manager')
+    def test_main_success_systemd(self, mock_distro):
+        mock_distro.return_value = False
+
         class Test(object):
             def __init__(self):
                 self.logfile = '-'


### PR DESCRIPTION
The change in question won't be made until RHEL/CentOS 8.0, and not 7.6.
Fedora 29 has the NetworkManager plugin ifcfg-rh as stop gap until 8.0 versions are verified.