### PR TITLE
Add Alpine support

### DIFF
--- a/etc/nova-agent.alpine
+++ b/etc/nova-agent.alpine
@@ -1,0 +1,52 @@
+#!/sbin/openrc-run
+#
+# nova-agent
+#
+
+
+name="nova-agent"
+
+description="Agent for setting up clean servers on Xen"
+description_reload="Restart nova-agent"
+
+command="/usr/bin/$name"
+
+pidfile="/var/run/nova-agent.pid"
+lockfile="/var/lock/subsys/$name"
+logfile="/var/log/nova-agent.log"
+
+loglevel="info"
+
+extra_started_commands="reload"
+
+start() {
+    [ -x $command ] || exit 5
+    echo -n $"Starting $name: "
+    daemon $command -o $logfile -l $loglevel
+    retval=$?
+    echo
+    [ $retval -eq 0 ] && touch $lockfile
+    return $retval
+}
+
+stop() {
+    echo -n $"Stopping $name: "
+    killproc $command
+    retval=$?
+    echo
+    [ $retval -eq 0 ] && rm -f $lockfile
+    return $retval
+}
+
+restart() {
+    stop
+    start
+}
+
+reload() {
+    restart
+}
+
+force_reload() {
+    restart
+}

--- a/etc/nova-agent.alpine
+++ b/etc/nova-agent.alpine
@@ -14,12 +14,12 @@ pidfile="/var/run/nova-agent.pid"
 lockfile="/var/lock/subsys/$name"
 logfile="/var/log/nova-agent.log"
 
-loglevel="debug"
+loglevel="info"
 
 extra_started_commands="reload"
 
 depend() {
-  after xenstored
+  after xe-guest-utilities
 }
 
 start_pre() {

--- a/etc/nova-agent.alpine
+++ b/etc/nova-agent.alpine
@@ -10,16 +10,20 @@ description_reload="Restart nova-agent"
 
 command="/usr/bin/$name"
 
-pidfile="/run/nova-agent.pid"
+pidfile="/var/run/nova-agent.pid"
 lockfile="/var/lock/subsys/$name"
 logfile="/var/log/nova-agent.log"
 
-loglevel="info"
+loglevel="debug"
 
 extra_started_commands="reload"
 
+depend() {
+  after xenstored
+}
+
 start_pre() {
-  [ -x $command ] || exit 5
+  [ -x "$command" ] || exit 5
 }
 
 start() {
@@ -31,19 +35,27 @@ start() {
     --make-pidfile \
     --pidfile "$pidfile" \
     -- \
+      --no-fork true \
       -o "$logfile" \
       -l "$loglevel"
-  eend $?
+  RETVAL=$?
+  if [ "$RETVAL" = "0" ]; then
+    mkdir -p "${lockfile%/*}"
+    touch "$lockfile"
+  fi
+  eend $RETVAL
 }
 
 stop() {
   ebegin "Stopping $name"
   start-stop-daemon \
     --stop \
-    --exec "$command" \
-    --pidfile "$pidfile" \
-    --quiet
-  eend $?
+    --pidfile "$pidfile"
+  RETVAL=$?
+  if [ "$RETVAL" = "0" ]; then
+    rm -f "$lockfile"
+  fi
+  eend $RETVAL
 }
 
 restart() {

--- a/etc/nova-agent.alpine
+++ b/etc/nova-agent.alpine
@@ -19,50 +19,50 @@ loglevel="info"
 extra_started_commands="reload"
 
 depend() {
-  after xe-guest-utilities
+    after xe-guest-utilities
 }
 
 start_pre() {
-  [ -x "$command" ] || exit 5
+    [ -x "$command" ] || exit 5
 }
 
 start() {
-  ebegin "Starting $name"
-  start-stop-daemon \
-    --background \
-    --start \
-    --exec "$command" \
-    --make-pidfile \
-    --pidfile "$pidfile" \
-    -- \
-      --no-fork true \
-      -o "$logfile" \
-      -l "$loglevel"
-  RETVAL=$?
-  if [ "$RETVAL" = "0" ]; then
-    mkdir -p "${lockfile%/*}"
-    touch "$lockfile"
-  fi
-  eend $RETVAL
+    ebegin "Starting $name"
+    start-stop-daemon \
+        --background \
+        --start \
+        --exec "$command" \
+        --make-pidfile \
+        --pidfile "$pidfile" \
+        -- \
+          --no-fork true \
+          -o "$logfile" \
+          -l "$loglevel"
+    RETVAL=$?
+    if [ "$RETVAL" = "0" ]; then
+        mkdir -p "${lockfile%/*}"
+        touch "$lockfile"
+    fi
+    eend $RETVAL
 }
 
 stop() {
-  ebegin "Stopping $name"
-  start-stop-daemon \
-    --stop \
-    --pidfile "$pidfile"
-  RETVAL=$?
-  if [ "$RETVAL" = "0" ]; then
-    rm -f "$lockfile"
-  fi
-  eend $RETVAL
+    ebegin "Stopping $name"
+    start-stop-daemon \
+        --stop \
+        --pidfile "$pidfile"
+    RETVAL=$?
+    if [ "$RETVAL" = "0" ]; then
+        rm -f "$lockfile"
+    fi
+    eend $RETVAL
 }
 
 restart() {
-  stop
-  start
+    stop
+    start
 }
 
 reload() {
-  restart
+    restart
 }

--- a/etc/nova-agent.alpine
+++ b/etc/nova-agent.alpine
@@ -19,34 +19,41 @@ loglevel="info"
 
 extra_started_commands="reload"
 
+start_pre() {
+  [ -x $command ] || exit 5
+}
+
 start() {
-    [ -x $command ] || exit 5
-    echo -n $"Starting $name: "
-    daemon $command -o $logfile -l $loglevel
-    retval=$?
-    echo
-    [ $retval -eq 0 ] && touch $lockfile
-    return $retval
+  ebegin $"Starting $name"
+  start-stop-daemon \
+    --signal HUP \
+    --exec "$command" \
+    --pidfile "$pidfile" \
+    -- \
+      -o "$logfile" \
+      -l "$loglevel"
+  eend $?
 }
 
 stop() {
-    echo -n $"Stopping $name: "
-    killproc $command
-    retval=$?
-    echo
-    [ $retval -eq 0 ] && rm -f $lockfile
-    return $retval
+  ebegin $"Stopping $name"
+  start-stop-daemon \
+    --stop \
+    --exec "$command" \
+    --pidfile "$pidfile" \
+    --quiet
+  eend $?
 }
 
 restart() {
-    stop
-    start
+  stop
+  start
 }
 
 reload() {
-    restart
+  restart
 }
 
 force_reload() {
-    restart
+  restart
 }

--- a/etc/nova-agent.alpine
+++ b/etc/nova-agent.alpine
@@ -3,7 +3,6 @@
 # nova-agent
 #
 
-
 name="nova-agent"
 
 description="Agent for setting up clean servers on Xen"
@@ -11,7 +10,7 @@ description_reload="Restart nova-agent"
 
 command="/usr/bin/$name"
 
-pidfile="/var/run/nova-agent.pid"
+pidfile="/run/nova-agent.pid"
 lockfile="/var/lock/subsys/$name"
 logfile="/var/log/nova-agent.log"
 
@@ -24,10 +23,12 @@ start_pre() {
 }
 
 start() {
-  ebegin $"Starting $name"
+  ebegin "Starting $name"
   start-stop-daemon \
-    --signal HUP \
+    --background \
+    --start \
     --exec "$command" \
+    --make-pidfile \
     --pidfile "$pidfile" \
     -- \
       -o "$logfile" \
@@ -36,7 +37,7 @@ start() {
 }
 
 stop() {
-  ebegin $"Stopping $name"
+  ebegin "Stopping $name"
   start-stop-daemon \
     --stop \
     --exec "$command" \
@@ -51,9 +52,5 @@ restart() {
 }
 
 reload() {
-  restart
-}
-
-force_reload() {
   restart
 }

--- a/novaagent/libs/alpine.py
+++ b/novaagent/libs/alpine.py
@@ -4,7 +4,6 @@ from __future__ import absolute_import
 
 import logging
 import time
-import os
 
 
 from subprocess import PIPE

--- a/novaagent/libs/alpine.py
+++ b/novaagent/libs/alpine.py
@@ -133,7 +133,7 @@ class ServerOS(DefaultOS):
             ifaces[iface] = utils.get_interface(mac, client)
 
         # Backup original configuration file
-        utils.backup_file(config_file)
+        utils.backup_file(self.netconfig_file)
 
         # Setup interfaces file
         self._setup_loopback()

--- a/novaagent/libs/alpine.py
+++ b/novaagent/libs/alpine.py
@@ -1,0 +1,278 @@
+
+from __future__ import absolute_import
+
+
+import logging
+import time
+import yaml
+import os
+
+
+from subprocess import PIPE
+from subprocess import Popen
+
+
+from novaagent import utils
+from novaagent.libs import DefaultOS
+
+
+log = logging.getLogger(__name__)
+
+
+class ServerOS(DefaultOS):
+    def __init__(self):
+        super(ServerOS, self).__init__()
+        self.netplan_file = '/etc/netplan/rackspace-cloud.yaml'
+        self.netconfig_file = '/etc/network/interfaces'
+
+    def _setup_loopback(self):
+        with open(self.netconfig_file, 'w') as iffile:
+            iffile.write('# The loopback network interface\n')
+            iffile.write('auto lo\n')
+            iffile.write('iface lo inet loopback\n\n')
+
+    def _setup_interfaces(self, ifname, iface):
+        with open(self.netconfig_file, 'a') as iffile:
+            iffile.write('# Label {0}\n'.format(iface['label']))
+            for count, x in enumerate(iface['ips']):
+                if count == 0:
+                    iffile.write('\nauto {0}\n'.format(ifname))
+                    iffile.write('iface {0} inet static\n'.format(ifname))
+                    iffile.write('\taddress {0}\n'.format(x['ip']))
+                    iffile.write('\tnetmask {0}\n'.format(x['netmask']))
+                    if iface.get('gateway'):
+                        iffile.write(
+                            '\tgateway {0}\n'.format(
+                                iface['gateway']
+                            )
+                        )
+
+                    if iface.get('dns'):
+                        iffile.write(
+                            '\tdns-nameservers {0}\n'.format(
+                                ' '.join(iface['dns'])
+                            )
+                        )
+
+                    if 'routes' in iface:
+                        for route in iface['routes']:
+                            iffile.write(
+                                '\tpost-up route add -net {0} netmask '
+                                '{1} gw {2} || true\n'.format(
+                                    route['route'],
+                                    route['netmask'],
+                                    route['gateway']
+                                )
+                            )
+                            iffile.write(
+                                '\tpost-down route add -net {0} netmask '
+                                '{1} gw {2} || true\n'.format(
+                                    route['route'],
+                                    route['netmask'],
+                                    route['gateway']
+                                )
+                            )
+
+                else:
+                    iffile.write('\nauto {0}:{1}\n'.format(ifname, count))
+                    iffile.write(
+                        'iface {0}:{1} inet static\n'.format(
+                            ifname,
+                            count
+                        )
+                    )
+                    iffile.write('\taddress {0}\n'.format(x['ip']))
+                    iffile.write('\tnetmask {0}\n'.format(x['netmask']))
+
+            if iface.get('ip6s'):
+                for count, ip_info in enumerate(iface['ip6s']):
+                    if count == 0:
+                        iffile.write(
+                            '\niface {0} inet6 static\n'.format(ifname)
+                        )
+                        iffile.write('\taddress {0}\n'.format(ip_info['ip']))
+                        iffile.write(
+                            '\tnetmask {0}\n'.format(
+                                ip_info['netmask']
+                            )
+                        )
+
+                        if 'gateway_v6' in iface and iface['gateway_v6']:
+                            iffile.write(
+                                '\tgateway {0}\n'.format(
+                                    iface['gateway_v6']
+                                )
+                            )
+
+                    else:
+                        iffile.write(
+                            '\niface {0}:{1} inet6 static\n'.format(
+                                ifname,
+                                count
+                            )
+                        )
+                        iffile.write('\taddress {0}'.format(ip_info['ip']))
+                        iffile.write(
+                            '\tnetmask {0}\n'.format(
+                                ip_info['netmask']
+                            )
+                        )
+
+            iffile.write('\n')
+
+    def _setup_netplan(self, ifaces):
+        # Setup netplan file from xenstore network info
+        temp_network = {
+            'version': 2,
+            'renderer': 'networkd',
+            'ethernets': {}
+        }
+        for ifname, iface in ifaces.items():
+            temp_net = {'addresses': [], 'dhcp4': False}
+            for temp_ip in iface['ips']:
+                temp_net['addresses'].append(
+                    '{0}/{1}'.format(
+                        temp_ip.get('ip'),
+                        utils.netmask_to_prefix(temp_ip.get('netmask'))
+                    )
+                )
+
+            if iface.get('gateway'):
+                temp_net['gateway4'] = iface.get('gateway')
+
+            if iface.get('ip6s'):
+                temp_net['dhcp6'] = False
+                temp_net['gateway6'] = iface.get('gateway_v6')
+                for temp_ipv6 in iface['ip6s']:
+                    temp_net['addresses'].append(
+                        '{0}/{1}'.format(
+                            temp_ipv6.get('ip'),
+                            temp_ipv6.get('netmask')
+                        )
+                    )
+
+            if iface.get('dns'):
+                temp_net['nameservers'] = {
+                    'addresses': iface.get('dns')
+                }
+
+            if iface.get('routes'):
+                temp_net['routes'] = []
+                for route in iface.get('routes'):
+                    temp_route = {}
+                    temp_route['to'] = '{0}/{1}'.format(
+                        route.get('route'),
+                        utils.netmask_to_prefix(route.get('netmask'))
+                    )
+                    temp_route['via'] = route.get('gateway')
+                    temp_net['routes'].append(temp_route)
+
+            temp_network['ethernets'][ifname] = temp_net
+
+        # Setup full dictionary and write to yaml file
+        netplan_data = {'network': temp_network}
+        with open(self.netplan_file, 'w') as netplan_file:
+            yaml.dump(netplan_data, netplan_file, default_flow_style=False)
+
+    def resetnetwork(self, name, value, client):
+        ifaces = {}
+        hostname_return_code, _ = self._setup_hostname(client)
+        if hostname_return_code != 0:
+            log.error('Error setting hostname on system')
+
+        xen_macs = utils.list_xenstore_macaddrs(client)
+        for iface in utils.list_hw_interfaces():
+            mac = utils.get_hw_addr(iface)
+            if not mac or mac not in xen_macs:
+                continue
+
+            ifaces[iface] = utils.get_interface(mac, client)
+
+        use_netplan = False
+        config_file = self.netconfig_file
+        if os.path.exists('/usr/sbin/netplan'):
+            use_netplan = True
+            config_file = self.netplan_file
+
+        # Backup original configuration file
+        utils.backup_file(config_file)
+
+        # Check if system is using netplan or not
+        if use_netplan:
+            # Setup netplan config file
+            self._setup_netplan(ifaces)
+
+            # Apply the netplan policy
+            p = Popen(
+                ['netplan', 'apply'],
+                stdout=PIPE,
+                stderr=PIPE,
+                stdin=PIPE
+            )
+            out, err = p.communicate()
+            if p.returncode != 0:
+                return (
+                    str(p.returncode),
+                    'Error applying netplan: {0}'.format(str(err))
+                )
+        else:
+            # Setup interfaces file
+            self._setup_loopback()
+            for ifname, iface in ifaces.items():
+                self._setup_interfaces(ifname, iface)
+
+            # Loop through the interfaces and restart networking
+            for ifname in ifaces.keys():
+                p = Popen(
+                    ['ifdown', ifname],
+                    stdout=PIPE,
+                    stderr=PIPE,
+                    stdin=PIPE
+                )
+                out, err = p.communicate()
+                if p.returncode != 0:
+                    return (
+                        str(p.returncode),
+                        'Error stopping network: {0}'.format(ifname)
+                    )
+
+                """
+                In some cases interfaces may retain old IP addresses especially
+                when building from a custom image. To prevent that we will do a
+                flush of the interface before bringing it back up.
+
+                Refer to bug:
+                https://bugs.launchpad.net/ubuntu/+source/ifupdown/+bug/1584682
+                """
+                p = Popen(
+                    ['ip', 'addr', 'flush', 'dev', ifname],
+                    stdout=PIPE,
+                    stderr=PIPE,
+                    stdin=PIPE
+                )
+                out, err = p.communicate()
+                if p.returncode != 0:
+                    return (
+                        str(p.returncode),
+                        'Error flushing network: {0}'.format(ifname)
+                    )
+
+                # Sleep for one second
+                time.sleep(1)
+                p = Popen(
+                    ['ifup', ifname],
+                    stdout=PIPE,
+                    stderr=PIPE,
+                    stdin=PIPE
+                )
+                out, err = p.communicate()
+                if p.returncode != 0:
+                    log.error(
+                        'Error received on network restart: {0}'.format(err)
+                    )
+                    return (
+                        str(p.returncode),
+                        'Error starting network: {0}'.format(ifname)
+                    )
+
+        return ('0', '')

--- a/novaagent/novaagent.py
+++ b/novaagent/novaagent.py
@@ -14,10 +14,10 @@ from pyxs.client import Client
 
 
 from novaagent.xenbus import XenGuestRouter
+from novaagent.libs import alpine
 from novaagent.libs import centos
 from novaagent.libs import debian
 from novaagent.libs import redhat
-from novaagent.libs import alpine
 from novaagent import utils
 
 
@@ -101,7 +101,9 @@ def nova_agent_listen(server_type, server_os, notify, server_init):
 
 def get_server_type():
     server_type = None
-    if (
+    if os.path.exists('/etc/alpine-release'):
+        server_type = alpine
+    elif (
         os.path.exists('/etc/centos-release') or
         os.path.exists('/etc/fedora-release')
     ):
@@ -110,8 +112,6 @@ def get_server_type():
         server_type = redhat
     elif os.path.exists('/etc/debian_version'):
         server_type = debian
-    elif os.path.exists('/etc/alpine-release'):
-        server_type = alpine
 
     return server_type
 

--- a/novaagent/novaagent.py
+++ b/novaagent/novaagent.py
@@ -17,6 +17,7 @@ from novaagent.xenbus import XenGuestRouter
 from novaagent.libs import centos
 from novaagent.libs import debian
 from novaagent.libs import redhat
+from novaagent.libs import alpine
 from novaagent import utils
 
 
@@ -109,6 +110,8 @@ def get_server_type():
         server_type = redhat
     elif os.path.exists('/etc/debian_version'):
         server_type = debian
+    elif os.path.exists('/etc/alpine-release'):
+        server_type = alpine
 
     return server_type
 

--- a/setup.py
+++ b/setup.py
@@ -26,9 +26,9 @@ def make_executable(path):
     os.chmod(path, mode)
 
 # https://stackoverflow.com/a/36902139
-class PostInstallCommand(install):
+class PostInstallCommand(setuptools.command.install):
     def run(self):
-        install.run(self)
+        setuptools.command.install.run(self)
         file_from = None
         file_to = None
         is_executable = True

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,9 @@
 import setuptools
 import novaagent
 import sys
-
+import os
+import stat
+from shutil import copyfile
 
 requirements = ['netifaces', 'pyxs', 'pycrypto', 'PyYaml', 'distro']
 if sys.version_info[:2] < (2, 7):
@@ -14,8 +16,33 @@ test_requirements = ['mock', 'nose']
 if sys.version_info[:2] < (2, 7):
     test_requirements.extend(['flake8 < 3', 'unittest2'])
 else:
+
     test_requirements.append('flake8')
 
+# https://stackoverflow.com/a/30463972
+def make_executable(path):
+    mode = os.stat(path).st_mode
+    mode |= (mode & 0o444) >> 2    # copy R bits to X
+    os.chmod(path, mode)
+
+# https://stackoverflow.com/a/36902139
+class PostInstallCommand(install):
+  def run(self):
+    install.run(self)
+    file_from = None
+    file_to = None
+    is_executable = True
+
+    dirname = os.path.dirname(__file__)
+
+    if os.path.exists('/etc/alpine-release'):
+      file_from = os.path.join(dirname, 'etc/nova-agent.alpine')
+      file_to = '/etc/init.d/nova-agent'
+
+    if file_from != None and file_to != None:
+      copyfile(file_from, file_to)
+      if is_executable:
+        make_executable(file_to)
 
 setuptools.setup(
     name='novaagent',

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ import sys
 import os
 import stat
 from shutil import copyfile
+from setuptools.command.install import install
 
 requirements = ['netifaces', 'pyxs', 'pycrypto', 'PyYaml', 'distro']
 if sys.version_info[:2] < (2, 7):
@@ -26,9 +27,9 @@ def make_executable(path):
     os.chmod(path, mode)
 
 # https://stackoverflow.com/a/36902139
-class PostInstallCommand(setuptools.command.install):
+class PostInstallCommand(install):
     def run(self):
-        setuptools.command.install.run(self)
+        install.run(self)
         file_from = None
         file_to = None
         is_executable = True

--- a/setup.py
+++ b/setup.py
@@ -3,10 +3,7 @@
 import setuptools
 import novaagent
 import sys
-import os
-import stat
-from shutil import copyfile
-from setuptools.command.install import install
+
 
 requirements = ['netifaces', 'pyxs', 'pycrypto', 'PyYaml', 'distro']
 if sys.version_info[:2] < (2, 7):
@@ -17,33 +14,8 @@ test_requirements = ['mock', 'nose']
 if sys.version_info[:2] < (2, 7):
     test_requirements.extend(['flake8 < 3', 'unittest2'])
 else:
-
     test_requirements.append('flake8')
 
-# https://stackoverflow.com/a/30463972
-def make_executable(path):
-    mode = os.stat(path).st_mode
-    mode |= (mode & 0o444) >> 2    # copy R bits to X
-    os.chmod(path, mode)
-
-# https://stackoverflow.com/a/36902139
-class PostInstallCommand(install):
-    def run(self):
-        install.run(self)
-        file_from = None
-        file_to = None
-        is_executable = True
-
-        dirname = os.path.dirname(__file__)
-
-        if os.path.exists('/etc/alpine-release'):
-            file_from = os.path.join(dirname, 'etc/nova-agent.alpine')
-            file_to = '/etc/init.d/nova-agent'
-
-        if file_from != None and file_to != None:
-            copyfile(file_from, file_to)
-            if is_executable:
-                make_executable(file_to)
 
 setuptools.setup(
     name='novaagent',
@@ -57,9 +29,6 @@ setuptools.setup(
     install_requires=requirements,
     extras_require={
         'tests': test_requirements
-    },
-    cmdclass={
-        'install': PostInstallCommand
     },
     entry_points={
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -27,22 +27,22 @@ def make_executable(path):
 
 # https://stackoverflow.com/a/36902139
 class PostInstallCommand(install):
-  def run(self):
-    install.run(self)
-    file_from = None
-    file_to = None
-    is_executable = True
+    def run(self):
+        install.run(self)
+        file_from = None
+        file_to = None
+        is_executable = True
 
-    dirname = os.path.dirname(__file__)
+        dirname = os.path.dirname(__file__)
 
-    if os.path.exists('/etc/alpine-release'):
-      file_from = os.path.join(dirname, 'etc/nova-agent.alpine')
-      file_to = '/etc/init.d/nova-agent'
+        if os.path.exists('/etc/alpine-release'):
+            file_from = os.path.join(dirname, 'etc/nova-agent.alpine')
+            file_to = '/etc/init.d/nova-agent'
 
-    if file_from != None and file_to != None:
-      copyfile(file_from, file_to)
-      if is_executable:
-        make_executable(file_to)
+        if file_from != None and file_to != None:
+            copyfile(file_from, file_to)
+            if is_executable:
+                make_executable(file_to)
 
 setuptools.setup(
     name='novaagent',
@@ -56,6 +56,9 @@ setuptools.setup(
     install_requires=requirements,
     extras_require={
         'tests': test_requirements
+    },
+    cmdclass={
+        'install': PostInstallCommand
     },
     entry_points={
         'console_scripts': [

--- a/tests/fixtures/network.py
+++ b/tests/fixtures/network.py
@@ -149,6 +149,62 @@ ALL_INTERFACES = {
     }
 }
 
+ALPINE_INTERFACES_CONFIG = [
+    '#This is a test file\n',
+    '# Label public\n',
+    '\n',
+    'auto eth0\n',
+    'iface eth0 inet static\n',
+    '\taddress 104.130.4.72\n',
+    '\tnetmask 255.255.255.0\n',
+    '\tgateway 104.130.4.1\n',
+    '\tdns-nameservers 69.20.0.164 69.20.0.196\n',
+    '\n',
+    'auto eth0:1\n',
+    'iface eth0:1 inet static\n',
+    '\taddress 104.130.4.73\n',
+    '\tnetmask 255.255.255.0\n',
+    '\n',
+    'iface eth0 inet6 static\n',
+    '\taddress 2001:4802:7802:104:be76:4eff:fe20:7572\n',
+    '\tnetmask 64\n',
+    '\tgateway fe80::def\n',
+    '\n',
+    'iface eth0:1 inet6 static\n',
+    '\taddress 2001:4802:7802:104:be76:4eff:fe20:7573\tnetmask 64\n',
+    '\n',
+    '# Label private\n',
+    '\n',
+    'auto eth1\n',
+    'iface eth1 inet static\n',
+    '\taddress 10.208.227.239\n',
+    '\tnetmask 255.255.224.0\n',
+    (
+        '\tpost-up route add -net 10.208.0.0 netmask 255.'
+        '240.0.0 gw 10.208.224.1 || true\n'
+    ),
+    (
+        '\tpost-down route add -net 10.208.0.0 netmask 255.'
+        '240.0.0 gw 10.208.224.1 || true\n'
+    ),
+    (
+        '\tpost-up route add -net 10.176.0.0 netmask 255.'
+        '240.0.0 gw 10.208.224.1 || true\n'
+    ),
+    (
+        '\tpost-down route add -net 10.176.0.0 netmask 255.'
+        '240.0.0 gw 10.208.224.1 || true\n'
+    ),
+    '\n'
+]
+
+ALPINE_INTERFACES_LOOPBACK = [
+    '# The loopback network interface\n',
+    'auto lo\n',
+    'iface lo inet loopback\n',
+    '\n'
+]
+
 CENTOS_NETWORK_FILE = [
     'NETWORKING=yes\n',
     'NOZEROCONF=yes\n',

--- a/tests/tests_libs_alpine.py
+++ b/tests/tests_libs_alpine.py
@@ -1,0 +1,527 @@
+
+from novaagent.libs import alpine
+from .fixtures import xen_data
+from .fixtures import network
+
+
+import logging
+import glob
+import copy
+import sys
+import os
+
+
+if sys.version_info[:2] >= (2, 7):
+    from unittest import TestCase
+else:
+    from unittest2 import TestCase
+
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+
+class TestHelpers(TestCase):
+    def setUp(self):
+        logging.disable(logging.ERROR)
+        self.time_patcher = mock.patch('novaagent.libs.alpine.time.sleep')
+        self.time_patcher.start()
+
+    def tearDown(self):
+        logging.disable(logging.NOTSET)
+        file_searches = [
+            '/tmp/hostname*',
+            '/tmp/interfaces*',
+            '/tmp/network*',
+            '/tmp/rackspace-cloud*'
+        ]
+        for search in file_searches:
+            route_files = glob.glob(search)
+            for item in route_files:
+                os.remove(item)
+
+        self.time_patcher.stop()
+
+    def setup_temp_hostname(self):
+        with open('/tmp/hostname', 'a+') as f:
+            f.write('test.hostname.local')
+
+    def setup_temp_interfaces(self):
+        with open('/tmp/interfaces', 'a+') as f:
+            f.write('#This is a test file\n')
+
+    def test_initialization(self):
+        temp = alpine.ServerOS()
+        self.assertEqual(
+            temp.netconfig_file,
+            '/etc/network/interfaces',
+            'Initialized netconfig file value does not match expected value'
+        )
+        self.assertEqual(
+            temp.hostname_file,
+            '/etc/hostname',
+            'Initialized hostname file value does not match expected value'
+        )
+
+    def test_setup_loopback(self):
+        temp = alpine.ServerOS()
+        temp.netconfig_file = '/tmp/interfaces'
+        temp._setup_loopback()
+
+        with open('/tmp/interfaces') as f:
+            written_data = f.readlines()
+
+        for index, line in enumerate(written_data):
+            self.assertEqual(
+                line,
+                network.ALPINE_INTERFACES_LOOPBACK[index],
+                'Written file did not match expected value'
+            )
+
+    def test_reset_network_hostname_failure(self):
+        self.setup_temp_hostname()
+        self.setup_temp_interfaces()
+        temp = alpine.ServerOS()
+        temp.hostname_file = '/tmp/hostname'
+        temp.netconfig_file = '/tmp/interfaces'
+        with mock.patch(
+            'novaagent.libs.alpine.ServerOS._setup_hostname'
+        ) as hostname:
+            hostname.return_value = 1, 'temp.hostname'
+            with mock.patch('novaagent.utils.list_xenstore_macaddrs') as mac:
+                mac.return_value = ['BC764E207572', 'BC764E206C5B']
+                with mock.patch('novaagent.utils.list_hw_interfaces') as hwint:
+                    hwint.return_value = ['eth0', 'eth1']
+                    mock_hw_address = mock.Mock()
+                    mock_hw_address.side_effect = [
+                        'BC764E207572',
+                        'BC764E206C5B'
+                    ]
+                    with mock.patch(
+                        'novaagent.utils.get_hw_addr',
+                        side_effect=mock_hw_address
+                    ):
+                        mock_interface = mock.Mock()
+                        mock_interface.side_effect = [
+                            network.ETH0_INTERFACE,
+                            xen_data.check_network_interface()
+                        ]
+                        with mock.patch(
+                            'novaagent.utils.get_interface',
+                            side_effect=mock_interface
+                        ):
+                            mock_popen = mock.Mock()
+                            mock_comm = mock.Mock()
+                            mock_comm.return_value = ('out', 'error')
+                            mock_popen.side_effect = [
+                                mock.Mock(returncode=0, communicate=mock_comm),
+                                mock.Mock(returncode=0, communicate=mock_comm),
+                                mock.Mock(returncode=0, communicate=mock_comm),
+                                mock.Mock(returncode=0, communicate=mock_comm),
+                                mock.Mock(returncode=0, communicate=mock_comm),
+                                mock.Mock(returncode=0, communicate=mock_comm)
+                            ]
+                            with mock.patch(
+                                'novaagent.libs.alpine.Popen',
+                                side_effect=mock_popen
+                            ):
+                                result = temp.resetnetwork(
+                                    'name',
+                                    'value',
+                                    'dummy_client'
+                                )
+
+        self.assertEqual(
+            result,
+            ('0', ''),
+            'Result was not the expected value'
+        )
+        interface_files = glob.glob('/tmp/interfaces*')
+        self.assertEqual(
+            len(interface_files),
+            2,
+            'Incorrect number of interface files'
+        )
+        with open('/tmp/interfaces') as f:
+            written_data = f.readlines()
+
+        update_config = copy.deepcopy(network.ALPINE_INTERFACES_CONFIG)
+        del update_config[0]
+        loopback = [
+            '# The loopback network interface\n',
+            'auto lo\n',
+            'iface lo inet loopback\n',
+            '\n'
+        ]
+        check_success = loopback + update_config
+        for index, line in enumerate(written_data):
+            self.assertIn(
+                line,
+                check_success,
+                'Written file did not match expected value'
+            )
+
+    def test_reset_network_error_down(self):
+        self.setup_temp_hostname()
+        self.setup_temp_interfaces()
+        temp = alpine.ServerOS()
+        temp.hostname_file = '/tmp/hostname'
+        temp.netconfig_file = '/tmp/interfaces'
+        with mock.patch(
+            'novaagent.libs.alpine.ServerOS._setup_hostname'
+        ) as hostname:
+            hostname.return_value = 0, 'temp.hostname'
+            with mock.patch('novaagent.utils.list_xenstore_macaddrs') as mac:
+                mac.return_value = ['BC764E206C5B']
+                with mock.patch('novaagent.utils.list_hw_interfaces') as hwint:
+                    hwint.return_value = ['eth1']
+                    mock_hw_address = mock.Mock()
+                    mock_hw_address.side_effect = [
+                        'BC764E206C5B'
+                    ]
+                    with mock.patch(
+                        'novaagent.utils.get_hw_addr',
+                        side_effect=mock_hw_address
+                    ):
+                        mock_interface = mock.Mock()
+                        mock_interface.side_effect = [
+                            xen_data.check_network_interface()
+                        ]
+                        with mock.patch(
+                            'novaagent.utils.get_interface',
+                            side_effect=mock_interface
+                        ):
+                            with mock.patch(
+                                'novaagent.libs.alpine.Popen'
+                            ) as p:
+                                p.return_value.communicate.return_value = (
+                                    'out', 'error'
+                                )
+                                p.return_value.returncode = 1
+                                result = temp.resetnetwork(
+                                    'name',
+                                    'value',
+                                    'dummy_client'
+                                )
+
+        self.assertEqual(
+            result,
+            ('1', 'Error stopping network: eth1'),
+            'Result was not the expected value'
+        )
+        interface_files = glob.glob('/tmp/interfaces*')
+        self.assertEqual(
+            len(interface_files),
+            2,
+            'Incorrect number of interface files'
+        )
+
+    def test_reset_network_error_flush(self):
+        self.setup_temp_hostname()
+        self.setup_temp_interfaces()
+        temp = alpine.ServerOS()
+        temp.hostname_file = '/tmp/hostname'
+        temp.netconfig_file = '/tmp/interfaces'
+        with mock.patch(
+            'novaagent.libs.alpine.ServerOS._setup_hostname'
+        ) as hostname:
+            hostname.return_value = 0, 'temp.hostname'
+            with mock.patch('novaagent.utils.list_xenstore_macaddrs') as mac:
+                mac.return_value = ['BC764E206C5B']
+                with mock.patch('novaagent.utils.list_hw_interfaces') as hwint:
+                    hwint.return_value = ['eth1']
+                    mock_hw_address = mock.Mock()
+                    mock_hw_address.side_effect = [
+                        'BC764E206C5B'
+                    ]
+                    with mock.patch(
+                        'novaagent.utils.get_hw_addr',
+                        side_effect=mock_hw_address
+                    ):
+                        mock_interface = mock.Mock()
+                        mock_interface.side_effect = [
+                            xen_data.check_network_interface()
+                        ]
+                        with mock.patch(
+                            'novaagent.utils.get_interface',
+                            side_effect=mock_interface
+                        ):
+                            mock_popen = mock.Mock()
+                            mock_comm = mock.Mock()
+                            mock_comm.return_value = ('out', 'error')
+                            mock_popen.side_effect = [
+                                mock.Mock(returncode=0, communicate=mock_comm),
+                                mock.Mock(returncode=1, communicate=mock_comm)
+                            ]
+                            with mock.patch(
+                                'novaagent.libs.alpine.Popen',
+                                side_effect=mock_popen
+                            ):
+                                result = temp.resetnetwork(
+                                    'name',
+                                    'value',
+                                    'dummy_client'
+                                )
+
+        self.assertEqual(
+            result,
+            ('1', 'Error flushing network: eth1'),
+            'Result was not the expected value'
+        )
+        interface_files = glob.glob('/tmp/interfaces*')
+        self.assertEqual(
+            len(interface_files),
+            2,
+            'Incorrect number of interface files'
+        )
+
+    def test_reset_network_error_up(self):
+        self.setup_temp_hostname()
+        self.setup_temp_interfaces()
+        temp = alpine.ServerOS()
+        temp.hostname_file = '/tmp/hostname'
+        temp.netconfig_file = '/tmp/interfaces'
+        with mock.patch(
+            'novaagent.libs.alpine.ServerOS._setup_hostname'
+        ) as hostname:
+            hostname.return_value = 0, 'temp.hostname'
+            with mock.patch('novaagent.utils.list_xenstore_macaddrs') as mac:
+                mac.return_value = ['BC764E206C5B']
+                with mock.patch('novaagent.utils.list_hw_interfaces') as hwint:
+                    hwint.return_value = ['eth1']
+                    mock_hw_address = mock.Mock()
+                    mock_hw_address.side_effect = [
+                        'BC764E206C5B'
+                    ]
+                    with mock.patch(
+                        'novaagent.utils.get_hw_addr',
+                        side_effect=mock_hw_address
+                    ):
+                        mock_interface = mock.Mock()
+                        mock_interface.side_effect = [
+                            xen_data.check_network_interface()
+                        ]
+                        with mock.patch(
+                            'novaagent.utils.get_interface',
+                            side_effect=mock_interface
+                        ):
+                            mock_popen = mock.Mock()
+                            mock_comm = mock.Mock()
+                            mock_comm.return_value = ('out', 'error')
+                            mock_popen.side_effect = [
+                                mock.Mock(returncode=0, communicate=mock_comm),
+                                mock.Mock(returncode=0, communicate=mock_comm),
+                                mock.Mock(returncode=1, communicate=mock_comm)
+                            ]
+                            with mock.patch(
+                                'novaagent.libs.alpine.Popen',
+                                side_effect=mock_popen
+                            ):
+                                result = temp.resetnetwork(
+                                    'name',
+                                    'value',
+                                    'dummy_client'
+                                )
+
+        self.assertEqual(
+            result,
+            ('1', 'Error starting network: eth1'),
+            'Result was not the expected value'
+        )
+        interface_files = glob.glob('/tmp/interfaces*')
+        self.assertEqual(
+            len(interface_files),
+            2,
+            'Incorrect number of interface files'
+        )
+
+    def test_reset_network_success(self):
+        self.setup_temp_hostname()
+        self.setup_temp_interfaces()
+        temp = alpine.ServerOS()
+        temp.hostname_file = '/tmp/hostname'
+        temp.netconfig_file = '/tmp/interfaces'
+        with mock.patch(
+            'novaagent.libs.alpine.ServerOS._setup_hostname'
+        ) as hostname:
+            hostname.return_value = 0, 'temp.hostname'
+            with mock.patch('novaagent.utils.list_xenstore_macaddrs') as mac:
+                mac.return_value = ['BC764E207572', 'BC764E206C5B']
+                with mock.patch('novaagent.utils.list_hw_interfaces') as hwint:
+                    hwint.return_value = ['eth0', 'eth1']
+                    mock_hw_address = mock.Mock()
+                    mock_hw_address.side_effect = [
+                        'BC764E207572',
+                        'BC764E206C5B'
+                    ]
+                    with mock.patch(
+                        'novaagent.utils.get_hw_addr',
+                        side_effect=mock_hw_address
+                    ):
+                        mock_interface = mock.Mock()
+                        mock_interface.side_effect = [
+                            network.ETH0_INTERFACE,
+                            xen_data.check_network_interface()
+                        ]
+                        with mock.patch(
+                            'novaagent.utils.get_interface',
+                            side_effect=mock_interface
+                        ):
+                            mock_popen = mock.Mock()
+                            mock_comm = mock.Mock()
+                            mock_comm.return_value = ('out', 'error')
+                            mock_popen.side_effect = [
+                                mock.Mock(returncode=0, communicate=mock_comm),
+                                mock.Mock(returncode=0, communicate=mock_comm),
+                                mock.Mock(returncode=0, communicate=mock_comm),
+                                mock.Mock(returncode=0, communicate=mock_comm),
+                                mock.Mock(returncode=0, communicate=mock_comm),
+                                mock.Mock(returncode=0, communicate=mock_comm)
+                            ]
+                            with mock.patch(
+                                'novaagent.libs.alpine.Popen',
+                                side_effect=mock_popen
+                            ):
+                                result = temp.resetnetwork(
+                                    'name',
+                                    'value',
+                                    'dummy_client'
+                                )
+
+        self.assertEqual(
+            result,
+            ('0', ''),
+            'Result was not the expected value'
+        )
+        interface_files = glob.glob('/tmp/interfaces*')
+        self.assertEqual(
+            len(interface_files),
+            2,
+            'Incorrect number of interface files'
+        )
+        with open('/tmp/interfaces') as f:
+            written_data = f.readlines()
+
+        update_config = copy.deepcopy(network.ALPINE_INTERFACES_CONFIG)
+        del update_config[0]
+        loopback = [
+            '# The loopback network interface\n',
+            'auto lo\n',
+            'iface lo inet loopback\n',
+            '\n'
+        ]
+        check_success = loopback + update_config
+        for index, line in enumerate(written_data):
+            self.assertIn(
+                line,
+                check_success,
+                'Written file did not match expected value'
+            )
+
+    def test_interface_setup(self):
+        self.setup_temp_interfaces()
+        temp = alpine.ServerOS()
+        temp.netconfig_file = '/tmp/interfaces'
+        temp_iface = network.ETH0_INTERFACE
+        temp._setup_interfaces('eth0', temp_iface)
+        temp_iface = xen_data.check_network_interface()
+        temp._setup_interfaces('eth1', temp_iface)
+        files = glob.glob('/tmp/interfaces*')
+        self.assertEqual(
+            len(files),
+            1,
+            'Did not find correct number of files'
+        )
+        with open('/tmp/interfaces') as f:
+            written_data = f.readlines()
+
+        for index, line in enumerate(written_data):
+            self.assertEqual(
+                line,
+                network.ALPINE_INTERFACES_CONFIG[index],
+                'Written file did not match expected value'
+            )
+
+    def test_setup_hostname_hostname_success(self):
+        self.setup_temp_hostname()
+        temp = alpine.ServerOS()
+        temp.hostname_file = '/tmp/hostname'
+        test_hostname = 'test.hostname'
+        with mock.patch('novaagent.utils.get_hostname') as hostname:
+            hostname.return_value = test_hostname
+            with mock.patch('novaagent.libs.os.path.exists') as exists:
+                exists.return_value = False
+                with mock.patch('novaagent.libs.Popen') as popen:
+                    popen.return_value.communicate.return_value = (
+                        ('out', 'err')
+                    )
+                    popen.return_value.returncode = 0
+                    return_code, _ = temp._setup_hostname(
+                        'dummy_client'
+                    )
+
+        self.assertEqual(
+            return_code,
+            0,
+            'Return code received was not expected value'
+        )
+
+        with open('/tmp/hostname') as f:
+            written_data = f.readlines()
+
+        for index, line in enumerate(written_data):
+            self.assertEqual(
+                line,
+                test_hostname,
+                'Did not find expected hostname in file'
+            )
+
+    def test_setup_hostname_hostnamectl_success(self):
+        self.setup_temp_hostname()
+        temp = alpine.ServerOS()
+        temp.hostname_file = '/tmp/hostname'
+        test_hostname = 'test.hostname'
+        with mock.patch('novaagent.utils.get_hostname') as hostname:
+            hostname.return_value = test_hostname
+            with mock.patch('novaagent.libs.os.path.exists') as exists:
+                exists.return_value = True
+                with mock.patch('novaagent.libs.Popen') as popen:
+                    popen.return_value.communicate.return_value = (
+                        ('out', 'err')
+                    )
+                    popen.return_value.returncode = 0
+                    return_code, _ = temp._setup_hostname(
+                        'dummy_client'
+                    )
+
+        self.assertEqual(
+            return_code,
+            0,
+            'Return code received was not expected value'
+        )
+
+    def test_setup_hostname_hostnamectl_and_hostname_failure(self):
+        self.setup_temp_hostname()
+        temp = alpine.ServerOS()
+        temp.hostname_file = '/tmp/hostname'
+        test_hostname = 'test.hostname'
+        with mock.patch('novaagent.utils.get_hostname') as hostname:
+            hostname.return_value = test_hostname
+            with mock.patch('novaagent.libs.os.path.exists') as exists:
+                exists.return_value = True
+                with mock.patch('novaagent.libs.Popen') as popen:
+                    popen.return_value.communicate.return_value = (
+                        ('out', 'err')
+                    )
+                    popen.return_value.returncode = 1
+                    return_code, _ = temp._setup_hostname(
+                        'dummy_client'
+                    )
+
+        self.assertEqual(
+            return_code,
+            1,
+            'Return code received was not expected value'
+        )

--- a/tests/tests_novaagent.py
+++ b/tests/tests_novaagent.py
@@ -416,10 +416,27 @@ class TestHelpers(TestCase):
                                     'An unknown exception was thrown'
                                 )
 
+    def test_server_type_alpine(self):
+        mock_response = mock.Mock()
+        mock_response.side_effect = [
+            True
+        ]
+        with mock.patch(
+            'novaagent.novaagent.os.path.exists',
+            side_effect=mock_response
+        ):
+            server_type = novaagent.novaagent.get_server_type()
+
+        self.assertEqual(
+            server_type.__name__,
+            'novaagent.libs.alpine',
+            'Did not get expected object for alpine'
+        )
+
     def test_server_type_debian(self):
         mock_response = mock.Mock()
         mock_response.side_effect = [
-            False, False, False, True
+            False, False, False, False, True
         ]
         with mock.patch(
             'novaagent.novaagent.os.path.exists',
@@ -436,7 +453,7 @@ class TestHelpers(TestCase):
     def test_server_type_redhat(self):
         mock_response = mock.Mock()
         mock_response.side_effect = [
-            False, False, True
+            False, False, False, True
         ]
         with mock.patch(
             'novaagent.novaagent.os.path.exists',
@@ -453,7 +470,7 @@ class TestHelpers(TestCase):
     def test_server_type_centos(self):
         mock_response = mock.Mock()
         mock_response.side_effect = [
-            False, True
+            False, False, True
         ]
         with mock.patch(
             'novaagent.novaagent.os.path.exists',


### PR DESCRIPTION
I mostly just copy/pasted what is in debian but deleted everything related to netplan.
I added a post install command to setup.py so that it could easily be installed with
```bash
pip install git+https://github.com/JourdanClark/nova-agent
```
It just copies `etc/nova-agent.alpine` to `/etc/init.d/nova-agent` and makes it executable.

I used this to install it on a fresh [Alpine Virtual](https://alpinelinux.org/downloads/) image

```bash
echo "Writing /etc/apk/repositories" ; \
cat <<'CONFIG' > /etc/apk/repositories
#/media/cdrom/apks
http://dl-3.alpinelinux.org/alpine/v3.8/main
http://dl-3.alpinelinux.org/alpine/v3.8/community
#http://dl-3.alpinelinux.org/alpine/edge/main
#http://dl-3.alpinelinux.org/alpine/edge/community
#http://dl-3.alpinelinux.org/alpine/edge/testing
CONFIG

echo "Installing pyxs for nova-agent" ; \
apk add \
    git \
    py-pip ; \
pip install git+https://github.com/selectel/pyxs.git --user pyxs

echo "Installing nova-agent" ; \
apk add \
    py-crypto \
    py-netifaces \
    py-yaml \
    xe-guest-utilities ; \
pip install git+https://github.com/JourdanClark/nova-agent ; \
rc-update add xe-guest-utilities boot ; \
rc-update add nova-agent boot
```